### PR TITLE
wam, jsoncpp: add jsoncpp, and make wam depend on it

### DIFF
--- a/recipes-devtools/jsoncpp/jsoncpp_1.8.4.bb
+++ b/recipes-devtools/jsoncpp/jsoncpp_1.8.4.bb
@@ -1,0 +1,22 @@
+# Copied from: http://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-devtools/jsoncpp/jsoncpp_1.8.4.bb
+SUMMARY = "JSON C++ lib used to read and write json file."
+DESCRIPTION = "Jsoncpp is an implementation of a JSON (http://json.org) reader \
+               and writer in C++. JSON (JavaScript Object Notation) is a \
+               lightweight data-interchange format. It is easy for humans to \
+               read and write. It is easy for machines to parse and generate."
+
+HOMEPAGE = "https://github.com/open-source-parsers/jsoncpp"
+
+SECTION = "libs"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=fa2a23dd1dc6c139f35105379d76df2b"
+
+SRCREV = "ddabf50f72cf369bf652a95c4d9fe31a1865a781"
+SRC_URI = "git://github.com/open-source-parsers/jsoncpp"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON -DJSONCPP_WITH_TESTS=OFF"

--- a/recipes-wam/wam/wam.bb
+++ b/recipes-wam/wam/wam.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 
 inherit qmake5
 
-DEPENDS = "qtbase glib-2.0 chromium53 wayland-ivi-extension libhomescreen libwindowmanager"
+DEPENDS = "qtbase glib-2.0 jsoncpp chromium53 wayland-ivi-extension libhomescreen libwindowmanager"
 
 PR="r0"
 


### PR DESCRIPTION
For Qt-less WAM, a new json implementation is needed. In this
case we use jsoncpp. This patch adds the recipe for building
jsoncpp in Yocto, and add it as a build dependency of wam.

[SPEC-1909] Qt-less WAM: add alternative json implementation to meta-agl-lge
[SPEC-1907] Qt-less WAM: do not use Qt JSON

Signed-off-by: Nick Diego Yamane <nickdiego@igalia.com>