### PR TITLE
mesa: add patches to fix swrast resize.

### DIFF
--- a/recipes-graphics/mesa/files/0001-wayland-egl-Resize-EGL-surface-on-update-buffer-for-.patch
+++ b/recipes-graphics/mesa/files/0001-wayland-egl-Resize-EGL-surface-on-update-buffer-for-.patch
@@ -1,0 +1,52 @@
+From f778d330c6e5a62ddca27b4129bdbd3be06d1be4 Mon Sep 17 00:00:00 2001
+From: Olivier Fourdan <ofourdan@redhat.com>
+Date: Thu, 25 Oct 2018 14:48:15 +0200
+Subject: wayland/egl: Resize EGL surface on update buffer for swrast
+
+After commit a9fb331ea ("wayland/egl: update surface size on window
+resize"), the surface size is updated as soon as the resize is done, and
+`update_buffers()` would resize only if the surface size differs from
+the attached size.
+
+However, in the case of swrast, there is no resize callback and the
+attached size is updated in `dri2_wl_swrast_commit_backbuffer()` prior
+to the `swrast_update_buffers()` so the attached size is always up to
+date when it reaches `swrast_update_buffers()` and the surface is never
+resized.
+
+This can be observed with "totem" using the GDK backend on Wayland (the
+default) when running on software rendering:
+
+  $ LIBGL_ALWAYS_SOFTWARE=true CLUTTER_BACKEND=gdk totem
+
+Resizing the window would leave the EGL surface size unchanged.
+
+To avoid the issue, partially revert the part of commit a9fb331ea for
+`swrast_update_buffers()` and resize on the win size and not the
+attached size.
+
+Fixes: a9fb331ea - wayland/egl: update surface size on window resize
+Signed-off-by: Olivier Fourdan <ofourdan@redhat.com>
+CC: Daniel Stone <daniel@fooishbar.org>
+CC: Juan A. Suarez Romero <jasuarez@igalia.com>
+CC: mesa-stable@lists.freedesktop.org
+Reviewed-by: Juan A. Suarez <jasuarez@igalia.com>
+
+diff --git a/src/egl/drivers/dri2/platform_wayland.c b/src/egl/drivers/dri2/platform_wayland.c
+index 52545163770..d139296c4cd 100644
+--- a/src/egl/drivers/dri2/platform_wayland.c
++++ b/src/egl/drivers/dri2/platform_wayland.c
+@@ -1496,8 +1496,8 @@ swrast_update_buffers(struct dri2_egl_surface *dri2_surf)
+    if (dri2_surf->back)
+       return 0;
+ 
+-   if (dri2_surf->base.Width != dri2_surf->wl_win->attached_width ||
+-       dri2_surf->base.Height != dri2_surf->wl_win->attached_height) {
++   if (dri2_surf->base.Width != dri2_surf->wl_win->width ||
++       dri2_surf->base.Height != dri2_surf->wl_win->height) {
+ 
+       dri2_wl_release_buffers(dri2_surf);
+ 
+-- 
+2.17.1
+

--- a/recipes-graphics/mesa/files/0001-wayland-egl-initialize-window-surface-size-to-window.patch
+++ b/recipes-graphics/mesa/files/0001-wayland-egl-initialize-window-surface-size-to-window.patch
@@ -1,0 +1,58 @@
+From 7210f5ad4516016b15850506f473499ea6dee023 Mon Sep 17 00:00:00 2001
+From: "Juan A. Suarez Romero" <jasuarez@igalia.com>
+Date: Mon, 4 Jun 2018 10:22:49 +0000
+Subject: wayland/egl: initialize window surface size to window size
+
+When creating a windows surface with eglCreateWindowSurface(), the
+width and height returned by eglQuerySurface(EGL_{WIDTH,HEIGHT}) is
+invalid until buffers are updated (like calling glClear()).
+
+But according to EGL 1.5 spec, section 3.5.6 ("Surface Attributes"):
+
+  "Querying EGL_WIDTH and EGL_HEIGHT returns respectively the width and
+   height, in pixels, of the surface. For a window or pixmap surface,
+   these values are initially equal to the width and height of the
+   native window or pixmap with respect to which the surface was
+   created"
+
+This fixes dEQP-EGL.functional.color_clears.* CTS tests
+
+v2:
+- Do not modify attached_{width,height} (Daniel)
+- Do not update size on resizing window (Brendan)
+
+CC: Daniel Stone <daniel@fooishbar.org>
+CC: Brendan King <brendan.king@imgtec.com>
+CC: mesa-stable@lists.freedesktop.org
+Tested-by: Eric Engestrom <eric@engestrom.ch>
+Tested-by: Chad Versace <chadversary@chromium.org>
+Reviewed-by: Chad Versace <chadversary@chromium.org>
+Reviewed-by: Daniel Stone <daniels@collabora.com>
+
+diff --git a/src/egl/drivers/dri2/platform_wayland.c b/src/egl/drivers/dri2/platform_wayland.c
+index b8af6ef2531..966f483abdd 100644
+--- a/src/egl/drivers/dri2/platform_wayland.c
++++ b/src/egl/drivers/dri2/platform_wayland.c
+@@ -146,6 +146,9 @@ dri2_wl_create_window_surface(_EGLDriver *drv, _EGLDisplay *disp,
+       goto cleanup_surf;
+    }
+ 
++   dri2_surf->base.Width = window->width;
++   dri2_surf->base.Height = window->height;
++
+    dri2_surf->wl_win = window;
+    dri2_surf->wl_queue = wl_display_create_queue(dri2_dpy->wl_dpy);
+    if (!dri2_surf->wl_queue) {
+@@ -182,9 +185,6 @@ dri2_wl_create_window_surface(_EGLDriver *drv, _EGLDisplay *disp,
+    dri2_surf->wl_win->private = dri2_surf;
+    dri2_surf->wl_win->destroy_window_callback = destroy_window_callback;
+ 
+-   dri2_surf->base.Width =  -1;
+-   dri2_surf->base.Height = -1;
+-
+    config = dri2_get_dri_config(dri2_conf, EGL_WINDOW_BIT,
+                                 dri2_surf->base.GLColorspace);
+ 
+-- 
+2.17.1
+

--- a/recipes-graphics/mesa/files/0001-wayland-egl-update-surface-size-on-window-resize.patch
+++ b/recipes-graphics/mesa/files/0001-wayland-egl-update-surface-size-on-window-resize.patch
@@ -1,0 +1,79 @@
+From 32a0794e004359d2150e0e79cc82b76876b89613 Mon Sep 17 00:00:00 2001
+From: "Juan A. Suarez Romero" <jasuarez@igalia.com>
+Date: Wed, 6 Jun 2018 10:13:05 +0000
+Subject: wayland/egl: update surface size on window resize
+
+According to EGL 1.5 spec, section 3.10.1.1 ("Native Window Resizing"):
+
+  "If the native window corresponding to _surface_ has been resized
+   prior to the swap, _surface_ must be resized to match. _surface_ will
+   normally be resized by the EGL implementation at the time the native
+   window is resized. If the implementation cannot do this transparently
+   to the client, then *eglSwapBuffers* must detect the change and
+   resize surface prior to copying its pixels to the native window."
+
+So far, resizing a native window in Wayland/EGL was interpreted in Mesa
+as a request to resize, which is not executed until the first draw call.
+And hence, surface size is not updated until executing it. Thus,
+querying the surface size with eglQuerySurface() after a window resize
+still returns the old values.
+
+This commit updates the surface size values as soon as the resize is
+done, even when the real resize is done in the draw call. This makes the
+semantics that any native window resize request take effect inmediately,
+and if user calls eglQuerySurface() it will return the new resized
+values.
+
+v2: update surface size if there isn't a back surface (Daniel)
+
+CC: Daniel Stone <daniel@fooishbar.org>
+CC: mesa-stable@lists.freedesktop.org
+Reviewed-by: Daniel Stone <daniels@collabora.com>
+
+diff --git a/src/egl/drivers/dri2/platform_wayland.c b/src/egl/drivers/dri2/platform_wayland.c
+index 97c65e072be..52545163770 100644
+--- a/src/egl/drivers/dri2/platform_wayland.c
++++ b/src/egl/drivers/dri2/platform_wayland.c
+@@ -90,6 +90,17 @@ resize_callback(struct wl_egl_window *wl_win, void *data)
+    struct dri2_egl_display *dri2_dpy =
+       dri2_egl_display(dri2_surf->base.Resource.Display);
+ 
++   /* Update the surface size as soon as native window is resized; from user
++    * pov, this makes the effect that resize is done inmediately after native
++    * window resize, without requiring to wait until the first draw.
++    *
++    * A more detailed and lengthy explanation can be found at
++    * https://lists.freedesktop.org/archives/mesa-dev/2018-June/196474.html
++    */
++   if (!dri2_surf->back) {
++      dri2_surf->base.Width = wl_win->width;
++      dri2_surf->base.Height = wl_win->height;
++   }
+    dri2_dpy->flush->invalidate(dri2_surf->dri_drawable);
+ }
+ 
+@@ -467,8 +478,8 @@ update_buffers(struct dri2_egl_surface *dri2_surf)
+       dri2_egl_display(dri2_surf->base.Resource.Display);
+    int i;
+ 
+-   if (dri2_surf->base.Width != dri2_surf->wl_win->width ||
+-       dri2_surf->base.Height != dri2_surf->wl_win->height) {
++   if (dri2_surf->base.Width != dri2_surf->wl_win->attached_width ||
++       dri2_surf->base.Height != dri2_surf->wl_win->attached_height) {
+ 
+       dri2_wl_release_buffers(dri2_surf);
+ 
+@@ -1485,8 +1496,8 @@ swrast_update_buffers(struct dri2_egl_surface *dri2_surf)
+    if (dri2_surf->back)
+       return 0;
+ 
+-   if (dri2_surf->base.Width != dri2_surf->wl_win->width ||
+-       dri2_surf->base.Height != dri2_surf->wl_win->height) {
++   if (dri2_surf->base.Width != dri2_surf->wl_win->attached_width ||
++       dri2_surf->base.Height != dri2_surf->wl_win->attached_height) {
+ 
+       dri2_wl_release_buffers(dri2_surf);
+ 
+-- 
+2.17.1
+

--- a/recipes-graphics/mesa/mesa_17.1.7.bbappend
+++ b/recipes-graphics/mesa/mesa_17.1.7.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+            file://0001-wayland-egl-initialize-window-surface-size-to-window.patch \
+            file://0001-wayland-egl-update-surface-size-on-window-resize.patch \
+            file://0001-wayland-egl-Resize-EGL-surface-on-update-buffer-for-.patch \
+"


### PR DESCRIPTION
Launching web apps on qemux86 are crashing in the GPU thread. After
debugging, it seems the problem seems to be related to not properly
handling surface resize (and first size) for rendering.

Backported the 3 patches solving the problem upstream:

    From: "Juan A. Suarez Romero" <jasuarez@igalia.com>
    Date: Mon, 4 Jun 2018 10:22:49 +0000
    Subject: wayland/egl: initialize window surface size to window size

    From: "Juan A. Suarez Romero" <jasuarez@igalia.com>
    Date: Wed, 6 Jun 2018 10:13:05 +0000
    Subject: wayland/egl: update surface size on window resize

    From: Olivier Fourdan <ofourdan@redhat.com>
    Date: Thu, 25 Oct 2018 14:48:15 +0200
    Subject: wayland/egl: Resize EGL surface on update buffer for swrast

These avoid the crash, but we still cannot see the web applications, but
a black area.

[SPEC-1934] WAM: crash in browser process GPU thread launching apps in qemux86_64