### PR TITLE
wam: add boost/boost-filesystem as dependency

### DIFF
--- a/recipes-wam/wam/wam.bb
+++ b/recipes-wam/wam/wam.bb
@@ -5,7 +5,8 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 
 inherit qmake5
 
-DEPENDS = "qtbase glib-2.0 jsoncpp chromium53 wayland-ivi-extension libhomescreen libwindowmanager"
+DEPENDS = "qtbase glib-2.0 jsoncpp boost chromium53 wayland-ivi-extension libhomescreen libwindowmanager"
+
 
 PR="r0"
 
@@ -41,6 +42,6 @@ pkg_postinst_${PN}_append() {
     chsmack -a "*" /usr/lib/webappmanager/plugins/libwebappmgr-default-plugin.so
 }
 
-RDEPENDS_${PN} += "wam-tinyproxy"
+RDEPENDS_${PN} += "boost-filesystem wam-tinyproxy"
 FILES_${PN} += "${sysconfdir}/init ${sysconfdir}/wam ${libdir}/webappmanager/plugins/*.so ${systemd_user_unitdir}"
 


### PR DESCRIPTION
This patch adds boost as WAM dependency. It's necessary to be able to successfully build WAM after [[agl] Qt-less WAM: replace qt basic data structures](https://github.com/webosose/wam/pull/13) changes.

Signed-off-by: Nick Diego Yamane <nickdiego@igalia.com>