### PR TITLE
chromium53: enable data device manager

### DIFF
--- a/recipes-wam/chromium/chromium53.inc
+++ b/recipes-wam/chromium/chromium53.inc
@@ -53,6 +53,7 @@ GYP_DEFINES = "\
     use_ash=0\
     use_aura=1\
     use_cups=0\
+    use_data_device_manager=1\
     use_gnome_keyring=0\
     use_ibus=0\
     use_kerberos=0\


### PR DESCRIPTION
Set GYP define for enabling data device manager,
needed for full DnD support in WAM.

[SPEC-2000] Add Drag and Drop support to WAM