### PR TITLE
Add use-linux-v4l2 to enable hw accelerated video decoding.

### DIFF
--- a/recipes-wam/chromium/chromium68.bb
+++ b/recipes-wam/chromium/chromium68.bb
@@ -71,6 +71,11 @@ PACKAGECONFIG[jumbo] = "use_jumbo_build=true jumbo_file_merge_limit=${JUMBO_FILE
 
 PACKAGECONFIG[lttng] = "use_lttng=true,use_lttng=false,lttng-ust,lttng-tools lttng-modules babeltrace"
 
+# Chromium can use v4l2 device for hardware accelerated video decoding on such boards as Renesas R-car M3, for example.
+# In case of R-car m3, additional patches are required for gstreamer and v4l2apps.
+# See https://github.com/igel-oss/meta-browser-hwdecode/tree/igalia-chromium71.
+PACKAGECONFIG[use-linux-v4l2] = "use_v4l2_codec=true use_v4lplugin=true use_linux_v4l2_only=true"
+
 #custom_toolchain=\"//build/toolchain/linux/unbundle:default\"
 GN_ARGS = "\
     cros_host_ar=\"${BUILD_AR}\"\


### PR DESCRIPTION
We have patches in the chromium68, which enable a v4l2 device for
hw accelerated video decoding tested on Renesas R-car m3 board
(other boards to be confirmed. For example, on the Renesas board,
additional patches for v4l2gst and gstreamer are required -
https://github.com/igel-oss/meta-browser-hwdecode/tree/igalia-chromium71)

Add the following lines to local.conf (or local.dev.inc) to use
v4l2 device for hw accelerated video decoding:

PACKAGECONFIG_append_pn-chromium68 = " use-linux-v4l2"

Signed-off-by: Maksim Sisov <msisov@igalia.com>