### PR TITLE
runxdg: backport patches from guppy branches

### DIFF
--- a/recipes-demo-hmi/runxdg/files/0001-backport-use-appid-instead-of-appname-in-tap_shortcu.patch
+++ b/recipes-demo-hmi/runxdg/files/0001-backport-use-appid-instead-of-appname-in-tap_shortcu.patch
@@ -1,0 +1,119 @@
+From 6e8b8ee3100620635767318d775ab9c314e05ff0 Mon Sep 17 00:00:00 2001
+From: Nick Diego Yamane <nick@igalia.com>
+Date: Thu, 20 Dec 2018 20:54:57 -0400
+Subject: [PATCH 1/2] [backport] use appid instead of appname in "tap_shortcut"
+
+Now In homescreen-service used application_id to identify
+different application, so use appid instead of appname
+in "tap_shortcut" parameter.
+
+Bug-AGL: SPEC-1764
+
+Cherry-picked from (guppy branch):
+https://gerrit.automotivelinux.org/gerrit/gitweb?p=staging/xdg-launcher.git;a=commit;h=f0432213c7c40d70fef06f9ceb665463d23b32e6
+
+Change-Id: I078e851eb28ceb39d24e5e2b5362fd96822c0b7b
+Original Author: wang_zhiqiang <wang_zhiqiang@dl.cn.nexty-ele.com>
+Signed-off-by: Nick Diego Yamane <nick@igalia.com>
+---
+ .gitreview     |  2 +-
+ src/runxdg.cpp | 46 +++++++---------------------------------------
+ 2 files changed, 8 insertions(+), 40 deletions(-)
+
+diff --git a/.gitreview b/.gitreview
+index 122ae1fed880..bb2df9e325ec 100644
+--- a/.gitreview
++++ b/.gitreview
+@@ -1,5 +1,5 @@
+ [gerrit]
+ host=gerrit.automotivelinux.org
+ port=29418
+-project=staging/soundmanager
++project=staging/xdg-launcher
+ defaultbranch=flounder
+diff --git a/src/runxdg.cpp b/src/runxdg.cpp
+index 3ff942c1bdd1..1b9c08c7ac2f 100644
+--- a/src/runxdg.cpp
++++ b/src/runxdg.cpp
+@@ -35,6 +35,7 @@
+ #include "runxdg.hpp"
+ 
+ #define RUNXDG_CONFIG "runxdg.toml"
++#define AREA_NORMAL_FULL "normal.full"
+ 
+ void fatal(const char* format, ...)
+ {
+@@ -298,10 +299,7 @@ int RunXDG::init_wm (void)
+   std::function< void(json_object*) > h_syncdraw =
+       [this](json_object* object) {
+     AGL_DEBUG("Got Event_SyncDraw");
+-    json_object* obj = json_object_new_object();
+-    json_object_object_add(obj, this->m_wm->kKeyDrawingName,
+-                           json_object_new_string(this->m_role.c_str()));
+-    this->m_wm->endDraw(obj);
++    this->m_wm->endDraw(this->m_role.c_str());
+   };
+ 
+   std::function< void(json_object*) > h_flushdraw= [](json_object* object) {
+@@ -327,26 +325,8 @@ int RunXDG::init_hs (void)
+   }
+ 
+   std::function< void(json_object*) > handler = [this] (json_object* object) {
+-    json_object *val;
+-
+-    if (json_object_object_get_ex(object, "application_name", &val)) {
+-      const char *name = json_object_get_string(val);
+-
+-      AGL_DEBUG("Event_TapShortcut <%s>", name);
+-
+-      if (strcmp(name, this->m_role.c_str()) == 0) {
+-        // check app exist and re-launch if needed
+-        AGL_DEBUG("Activesurface %s ", this->m_role.c_str());
+-
+-        json_object *obj = json_object_new_object();
+-        json_object_object_add(obj, this->m_wm->kKeyDrawingName,
+-                               json_object_new_string(this->m_role.c_str()));
+-        json_object_object_add(obj, this->m_wm->kKeyDrawingArea,
+-                               json_object_new_string("normal.full"));
+-
+-        this->m_wm->activateSurface(obj);
+-      }
+-    }
++    AGL_DEBUG("Activesurface %s ", this->m_role.c_str());
++    this->m_wm->activateWindow(this->m_role.c_str(), AREA_NORMAL_FULL);
+   };
+   m_hs->set_event_handler(LibHomeScreen::Event_TapShortcut, handler);
+ 
+@@ -476,26 +456,14 @@ void RunXDG::setup_surface (int id)
+   std::string sid = std::to_string(id);
+ 
+   // This surface is mine, register pair app_name and ivi id.
+-  json_object *obj = json_object_new_object();
+-  json_object_object_add(obj, m_wm->kKeyDrawingName,
+-                         json_object_new_string(m_role.c_str()));
+-  json_object_object_add(obj, m_wm->kKeyIviId,
+-                         json_object_new_string(sid.c_str()));
+-
+-  AGL_DEBUG("requestSurfaceXDG(%s,%s)", m_role.c_str(), sid.c_str());
+-  m_wm->requestSurfaceXDG(obj);
++  AGL_DEBUG("requestSurfaceXDG(%s,%d)", m_role.c_str(), id);
++  m_wm->requestSurfaceXDG(this->m_role.c_str(), id);
+ 
+   if (m_pending_create) {
+     // Recovering 1st time tap_shortcut is dropped because
+     // the application has not been run yet (1st time launch)
+     m_pending_create = false;
+-
+-    json_object *obj = json_object_new_object();
+-    json_object_object_add(obj, m_wm->kKeyDrawingName,
+-                           json_object_new_string(m_role.c_str()));
+-    json_object_object_add(obj, m_wm->kKeyDrawingArea,
+-                           json_object_new_string("normal.full"));
+-    m_wm->activateSurface(obj);
++    m_wm->activateWindow(this->m_role.c_str(), AREA_NORMAL_FULL);
+   }
+ }
+ 
+-- 
+2.20.1
+

--- a/recipes-demo-hmi/runxdg/files/0002-backport-Force-set-unset-keyboard-focus.patch
+++ b/recipes-demo-hmi/runxdg/files/0002-backport-Force-set-unset-keyboard-focus.patch
@@ -1,0 +1,156 @@
+From bbbc4e445af8aa8ac3c5bf0534d6620f199a6f4d Mon Sep 17 00:00:00 2001
+From: Nick Diego Yamane <nick@igalia.com>
+Date: Thu, 20 Dec 2018 20:55:11 -0400
+Subject: [PATCH 2/2] [backport] Force set/unset keyboard focus
+
+This is work around which control keyboard focus for some
+applications on behalf of windowmanager or LayerManagerControl.
+
+Cherry-picked from (guppy branch):
+https://gerrit.automotivelinux.org/gerrit/gitweb?p=staging/xdg-launcher.git;a=commit;h=415e5cbb5787aa0429558b5256bf912231297431
+
+Change-Id: I8e73b3fd34c076d1023060dbeef7225eebb243ca
+Original Author: wang_zhiqiang <wang_zhiqiang@dl.cn.nexty-ele.com>
+Signed-off-by: Nick Diego Yamane <nick@igalia.com>
+---
+ CMakeLists.txt |  3 +++
+ src/runxdg.cpp | 26 ++++++++++++++++++--------
+ src/runxdg.hpp |  5 ++++-
+ 3 files changed, 25 insertions(+), 9 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index af5e6b7b7ff5..0166ece32898 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -10,6 +10,7 @@ find_package(PkgConfig REQUIRED)
+ pkg_check_modules(GLIB REQUIRED glib-2.0)
+ pkg_check_modules(GIO REQUIRED gio-2.0)
+ pkg_check_modules(ILMCONTROL REQUIRED ilmControl)
++pkg_check_modules(ILMINPUT REQUIRED ilmInput)
+ 
+ # No configuration
+ # configure_file (
+@@ -22,6 +23,7 @@ pkg_check_modules(ILMCONTROL REQUIRED ilmControl)
+ include_directories(
+   "include"
+   "${ILMCONTROL_INCLUDE_DIRS}"
++  "${ILMINPUT_INCLUDE_DIRS}"
+   "${GLIB_INCLUDE_DIRS}"
+   "${GIO_INCLUDE_DIRS}"
+   )
+@@ -34,6 +36,7 @@ SET(LIBRARIES
+   windowmanager
+   homescreen
+   ${ILMCONTROL_LIBRARIES}
++  ${ILMINPUT_LIBRARIES}
+   afbwsc
+   json-c
+   pthread
+diff --git a/src/runxdg.cpp b/src/runxdg.cpp
+index 1b9c08c7ac2f..33d5324d7c14 100644
+--- a/src/runxdg.cpp
++++ b/src/runxdg.cpp
+@@ -84,7 +84,8 @@ void RunXDG::notify_ivi_control_cb (ilmObjectType object, t_ilm_uint id,
+     m_launcher->register_surfpid(surf_pid);
+     if (m_launcher->m_rid &&
+         surf_pid == m_launcher->find_surfpid_by_rid(m_launcher->m_rid)) {
+-      setup_surface(id);
++      m_ivi_id = id;
++      setup_surface();
+     }
+     m_surfaces[surf_pid] = id;
+   } else if (object == ILM_LAYER) {
+@@ -280,12 +281,16 @@ int RunXDG::init_wm (void)
+     return -1;
+   }
+ 
+-  std::function< void(json_object*) > h_active = [](json_object* object) {
++  std::function< void(json_object*) > h_active = [this](json_object* object) {
+     AGL_DEBUG("Got Event_Active");
++    t_ilm_surface s_ids[1] = { this->m_ivi_id };
++    ilm_setInputFocus(s_ids, 1, ILM_INPUT_DEVICE_KEYBOARD, ILM_TRUE);
+   };
+ 
+-  std::function< void(json_object*) > h_inactive = [](json_object* object) {
++  std::function< void(json_object*) > h_inactive = [this](json_object* object) {
+     AGL_DEBUG("Got Event_Inactive");
++    t_ilm_surface s_ids[1] = { this->m_ivi_id };
++    ilm_setInputFocus(s_ids, 1, ILM_INPUT_DEVICE_KEYBOARD, ILM_FALSE);
+   };
+ 
+   std::function< void(json_object*) > h_visible = [](json_object* object) {
+@@ -451,13 +456,13 @@ RunXDG::RunXDG (int port, const char* token, const char* id)
+   AGL_DEBUG("RunXDG created.");
+ }
+ 
+-void RunXDG::setup_surface (int id)
++void RunXDG::setup_surface (void)
+ {
+-  std::string sid = std::to_string(id);
++  std::string sid = std::to_string(m_ivi_id);
+ 
+   // This surface is mine, register pair app_name and ivi id.
+-  AGL_DEBUG("requestSurfaceXDG(%s,%d)", m_role.c_str(), id);
+-  m_wm->requestSurfaceXDG(this->m_role.c_str(), id);
++  AGL_DEBUG("requestSurfaceXDG(%s,%d)", m_role.c_str(), m_ivi_id);
++  m_wm->requestSurfaceXDG(this->m_role.c_str(), (unsigned int)m_ivi_id);
+ 
+   if (m_pending_create) {
+     // Recovering 1st time tap_shortcut is dropped because
+@@ -556,6 +561,8 @@ void RunXDG::start (void)
+   AGL_DEBUG("waiting for notification: surafce created");
+   m_pending_create = true;
+ 
++  ilm_commitChanges();
++
+   // in case, target app has already run
+   if (m_launcher->m_rid) {
+     pid_t surf_pid = m_launcher->find_surfpid_by_rid(m_launcher->m_rid);
+@@ -567,10 +574,13 @@ void RunXDG::start (void)
+         int id = itr->second;
+         AGL_DEBUG("surface %d for <%s> already exists", id,
+                   m_role.c_str());
+-        setup_surface(id);
++        m_ivi_id = id;
++        setup_surface();
+       }
+     }
+   }
++
++  ilm_commitChanges();
+   m_launcher->loop(e_flag);
+ }
+ 
+diff --git a/src/runxdg.hpp b/src/runxdg.hpp
+index ce0c016ac981..595babe60246 100644
+--- a/src/runxdg.hpp
++++ b/src/runxdg.hpp
+@@ -30,6 +30,7 @@
+ #include <gio/gio.h>
+ 
+ #include <ilm/ilm_control.h>
++#include <ilm/ilm_input.h>
+ 
+ #include <libwindowmanager.h>
+ #include <libhomescreen.hpp>
+@@ -149,6 +150,8 @@ class RunXDG
+     LibHomeScreen *m_hs;
+     ILMControl *m_ic;
+ 
++    t_ilm_surface m_ivi_id;
++
+     std::map<int, int> m_surfaces;  // pair of <afm:rid, ivi:id>
+ 
+     bool m_pending_create = false;
+@@ -158,7 +161,7 @@ class RunXDG
+ 
+     int parse_config(const char *file);
+ 
+-    void setup_surface(int id);
++    void setup_surface(void);
+ };
+ 
+ #endif  // RUNXDG_HPP
+-- 
+2.20.1
+

--- a/recipes-demo-hmi/runxdg/runxdg_git.bbappend
+++ b/recipes-demo-hmi/runxdg/runxdg_git.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+            file://0001-backport-use-appid-instead-of-appname-in-tap_shortcu.patch \
+            file://0002-backport-Force-set-unset-keyboard-focus.patch \
+"


### PR DESCRIPTION
Backport guppy patches fixing the following critical issues:
 - use appid instead of appname in "tap_shortcut"
 - Force set/unset keyboard focus

Applying them temporarily here, until they get merged upstream[1][2]

[1] https://gerrit.automotivelinux.org/gerrit/#/c/19329
[2] https://gerrit.automotivelinux.org/gerrit/#/c/19331

Signed-off-by: Nick Diego Yamane <nickdiego@igalia.com>